### PR TITLE
解决svelte调用问题

### DIFF
--- a/src/js/controller.js
+++ b/src/js/controller.js
@@ -1,5 +1,5 @@
-import { isMobile, nameMap, getElementViewLeft, getElementViewTop, secondToTime } from './utils';
-import { orderList, orderRandom, loopOne, loopNone, loopAll } from './icons';
+import { isMobile, nameMap, getElementViewLeft, getElementViewTop, secondToTime } from './utils.js';
+import { orderList, orderRandom, loopOne, loopNone, loopAll } from './icons.js';
 
 export default (player) => {
     initPlayButton(player);

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,7 +1,7 @@
-import APlayer from './player';
+import APlayer from './player.js';
 
-import { fixedModeTplRenderer } from '../template/player';
-import { addToList, removeFromList, clearList } from './list';
+import { fixedModeTplRenderer } from '../template/player.js';
+import { addToList, removeFromList, clearList } from './list.js';
 
 export function APlayerFixedModePlugin(player) {
     player.tplRenderers = fixedModeTplRenderer

--- a/src/js/list.js
+++ b/src/js/list.js
@@ -1,6 +1,6 @@
 import tplListItem from '../template/list-item.js';
-import { secondToTime, randomOrder } from './utils';
-import { handleAudioOption } from './options';
+import { secondToTime, randomOrder } from './utils.js';
+import { handleAudioOption } from './options.js';
 
 export function addToList(player, audios) {
     player.events.trigger('listadd', {

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1,14 +1,14 @@
-import { secondToTime, isMobile, randomOrder } from './utils';
-import { pause, play, volumeDown, volumeOff, volumeUp } from './icons';
-import handleOption from './options';
-import Template from './template';
-import { notFixedModeTplRenderers } from '../template/player';
-import Bar from './bar';
-import Lrc from './lrc';
-import Controller from './controller';
-import Timer from './timer';
-import Events, { audioEvents } from './events';
-import List from './list';
+import { secondToTime, isMobile, randomOrder } from './utils.js';
+import { pause, play, volumeDown, volumeOff, volumeUp } from './icons.js';
+import handleOption from './options.js';
+import Template from './template.js';
+import { notFixedModeTplRenderers } from '../template/player.js';
+import Bar from './bar.js';
+import Lrc from './lrc.js';
+import Controller from './controller.js';
+import Timer from './timer.js';
+import Events, { audioEvents } from './events.js';
+import List from './list.js';
 
 const instances = [];
 

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -1,4 +1,4 @@
-export const isMobile = /mobile/i.test(window.navigator.userAgent);
+export const isMobile = false// /mobile/i.test(window.navigator.userAgent);
 
 /**
 * Parse second to time string

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -1,4 +1,11 @@
-export const isMobile = false// /mobile/i.test(window.navigator.userAgent);
+export const isMobile = (function () {
+    try {
+        return /mobile/i.test(window.navigator.userAgent);
+    } catch (e) {
+        console.error(e);
+        return false;
+    }
+})();
 
 /**
 * Parse second to time string

--- a/src/template/list-item.js
+++ b/src/template/list-item.js
@@ -1,4 +1,4 @@
-import $imports from './art-runtime';
+import $imports from './art-runtime.js';
 export default function ($data) {
     'use strict';
     $data = $data || {};

--- a/src/template/lrc.js
+++ b/src/template/lrc.js
@@ -1,4 +1,4 @@
-import $imports from './art-runtime';
+import $imports from './art-runtime.js';
 export default function ($data) {
     'use strict';
     $data = $data || {};

--- a/src/template/player.js
+++ b/src/template/player.js
@@ -1,5 +1,5 @@
-import $imports from './art-runtime';
-import { lrc, right, menu, play, loading, skip, volumeDown, orderList, loopOne, loopAll, loopNone, orderRandom } from '../js/icons'
+import $imports from './art-runtime.js';
+import { lrc, right, menu, play, loading, skip, volumeDown, orderList, loopOne, loopAll, loopNone, orderRandom } from '../js/icons.js'
 import listItem from './list-item.js';
 
 const $escape = $imports.$escape;


### PR DESCRIPTION
原来的代码无法直接使用svelte调用，会显示一系列源代码找不到的错误。我通过更改js文件的import方式，即将类似`import './aplayer'`的代码改为`import './aplayer.js'`解决。我没有弄清楚这样做的原理，但是这样做是可行且没有副作用的。
另外，在svelte中，`export const isMobile = /mobile/i.test(window.navigator.userAgent);`会由于找不到`window`引发致命错误，我使用一个简单的`try-catch`块进行了简单的处理。